### PR TITLE
Add GPU support for kWaveDiffusion

### DIFF
--- a/k-Wave/helpfiles/kWaveDiffusion.html
+++ b/k-Wave/helpfiles/kWaveDiffusion.html
@@ -203,6 +203,13 @@ perfusion coefficient [1/s] = B / A
     
     <tbody>
         
+		<tr valign="top">
+            <td bgcolor="#F2F2F2"><code>'DataCast'</code></td>
+            <td bgcolor="#F2F2F2"><em>(string of data type)</em></td>
+            <td bgcolor="#F2F2F2"><code>'off'</code></td>            
+            <td bgcolor="#F2F2F2">String input of the data type that variables are cast to before computation (default = <code>'off'</code>). For example, setting to <code>'single'</code> will speed up the computation time. To exploit GPU parallelisation via the Parallel Computing Toolbox, set <code>'DataCast'</code> to <code>'gpuArray-single'</code>. Note, the output variables are stored in the same data type. To transfer a <code>gpuArray</code> to the local workspace, use <code><a href="matlab: doc gpuarray.gather">gather</a></code>.</td>
+        </tr> 
+
         <tr valign="top">
             <td bgcolor="#F2F2F2"><code>'DisplayUpdates'</code></td>
             <td bgcolor="#F2F2F2"><em>(Boolean scalar)</em></td>

--- a/k-Wave/testing/unit/angularSpectrum_data_cast.m
+++ b/k-Wave/testing/unit/angularSpectrum_data_cast.m
@@ -5,10 +5,10 @@ function test_pass = angularSpectrum_data_cast(plot_comparisons, plot_simulation
 % ABOUT:
 %     author      - Bradley Treeby
 %     date        - 8th January 2019
-%     last update - 13th February 2019
+%     last update - 7th August 2023
 %       
 % This function is part of the k-Wave Toolbox (http://www.k-wave.org)
-% Copyright (C) 2019 Bradley Treeby
+% Copyright (C) 2023 Bradley Treeby
 
 % This file is part of k-Wave. k-Wave is free software: you can
 % redistribute it and/or modify it under the terms of the GNU Lesser
@@ -31,7 +31,7 @@ if nargin == 0
 end
 
 % set comparison threshold
-comparison_threshold_single = 1e-6;
+comparison_threshold_single = 2e-6;
 comparison_threshold_double = 1e-15;
 
 % set pass variable

--- a/k-Wave/testing/unit/kWaveArray_circle_of_point_detectors.m
+++ b/k-Wave/testing/unit/kWaveArray_circle_of_point_detectors.m
@@ -1,0 +1,131 @@
+function test_pass = kWaveArray_circle_of_point_detectors(plot_comparisons, plot_simulations)
+% DESCRIPTION:
+%       Unit test to compare a circle of off-grid point detectors.
+%
+% ABOUT:
+%       author      - Bradley Treeby
+%       date        - 31st May 2023
+%       last update - 31st May 2023
+%       
+% This function is part of the k-Wave Toolbox (http://www.k-wave.org)
+% Copyright (C) 2023 Bradley Treeby
+
+% This file is part of k-Wave. k-Wave is free software: you can
+% redistribute it and/or modify it under the terms of the GNU Lesser
+% General Public License as published by the Free Software Foundation,
+% either version 3 of the License, or (at your option) any later version.
+% 
+% k-Wave is distributed in the hope that it will be useful, but WITHOUT ANY
+% WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+% FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+% more details. 
+% 
+% You should have received a copy of the GNU Lesser General Public License
+% along with k-Wave. If not, see <http://www.gnu.org/licenses/>.
+
+% check for plot inputs, and set to true if nargin is zero (to allow the
+% test to be run independent of runUnitTests)
+if nargin == 0
+    plot_comparisons = true;
+    plot_simulations = true;
+end
+
+% set pass variable
+test_pass = true;
+
+% set comparison threshold
+comparison_thresh = 3;
+
+% =========================================================================
+% DEFINE GRID PROPERTIES
+% =========================================================================
+
+% grid properties
+Nx = 128;
+dx = 0.5e-3;
+Ny = 128;
+dy = 0.5e-3;
+kgrid = kWaveGrid(Nx, dx, Ny, dy);
+
+% medium properties
+medium.sound_speed = 1500;
+
+% time array
+kgrid.makeTime(medium.sound_speed, [], 40e-6);
+
+% set source
+source.p_mask = zeros(Nx, Ny);
+source.p_mask(Nx/2+1, Ny/2+1) = 1;
+source.p = createCWSignals(kgrid.t_array, 500e3, 1, 0, 5);
+
+% =========================================================================
+% SIMULATION WITH OFF-GRID SOURCE
+% =========================================================================
+
+% create empty array
+karray = kWaveArray('BLITolerance', 0.01);
+
+% add elements
+positions = makeCartCircle(15e-3, 100, [0, 0]);
+measure = 1;
+element_dim = 1;
+for ind = 1:length(positions)
+    karray.addCustomElement(positions(:, ind), measure, element_dim, 'Point');
+end
+
+% assign binary mask from karray to the sensor mask
+sensor.mask = karray.getArrayBinaryMask(kgrid);
+
+% run k-Wave simulation
+sensor_data = kspaceFirstOrder2D(kgrid, medium, source, sensor, ...
+    'PlotSim', plot_simulations, ...
+    'PMLInside', false, ...
+    'PlotPML', false);
+
+% combine data to give one trace per physical array element
+sensor_data = karray.combineSensorData(kgrid, sensor_data);
+
+% check all the traces are the same
+maxErr = 0;
+for ind = 2:length(positions)
+    err = 100 * max(abs(sensor_data(ind, :) - sensor_data(1, :))) / max(sensor_data(1, :));
+    if err > maxErr
+        maxErr = err;
+        maxErrInd = ind;
+    end
+end
+
+% check values are the same
+if maxErr > comparison_thresh
+    test_pass = false;
+end
+
+% =========================================================================
+% VISUALISATION
+% =========================================================================
+
+% plot sensor traces
+if plot_comparisons
+    
+    figure;
+    imagesc(sensor.mask);
+    title('Sensor mask');
+    axis image;
+
+    figure;
+    imagesc(sensor_data);
+    title('Sensor data');
+    colorbar;
+
+    figure;
+    subplot(2, 1, 1);
+    plot(kgrid.t_array, sensor_data(1, :), 'k-');
+    hold on;
+    plot(kgrid.t_array, sensor_data(maxErrInd, :), 'r--');
+    legend('Point 1', 'Point 2');
+
+    subplot(2, 1, 2);
+    plot(kgrid.t_array, 100 * abs(sensor_data(1, :) - sensor_data(maxErrInd, :)) ./ max(sensor_data(1, :)), 'k-');
+    ylabel('Error [%]');
+    
+end

--- a/k-Wave/testing/unit/kWaveArray_on_vs_off_grid_point_detector.m
+++ b/k-Wave/testing/unit/kWaveArray_on_vs_off_grid_point_detector.m
@@ -1,0 +1,124 @@
+function test_pass = kWaveArray_on_vs_off_grid_point_detector(plot_comparisons, plot_simulations)
+% DESCRIPTION:
+%       Unit test to compare an off-grid point detector created using the
+%       kWaveArray class with a point detector on grid.
+%
+% ABOUT:
+%       author      - Bradley Treeby
+%       date        - 31st May 2023
+%       last update - 31st May 2023
+%       
+% This function is part of the k-Wave Toolbox (http://www.k-wave.org)
+% Copyright (C) 2023 Bradley Treeby
+
+% This file is part of k-Wave. k-Wave is free software: you can
+% redistribute it and/or modify it under the terms of the GNU Lesser
+% General Public License as published by the Free Software Foundation,
+% either version 3 of the License, or (at your option) any later version.
+% 
+% k-Wave is distributed in the hope that it will be useful, but WITHOUT ANY
+% WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+% FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+% more details. 
+% 
+% You should have received a copy of the GNU Lesser General Public License
+% along with k-Wave. If not, see <http://www.gnu.org/licenses/>.
+
+% check for plot inputs, and set to true if nargin is zero (to allow the
+% test to be run independent of runUnitTests)
+if nargin == 0
+    plot_comparisons = true;
+    plot_simulations = true;
+end
+
+% set pass variable
+test_pass = true;
+
+% set comparison threshold
+comparison_thresh = 3;
+
+% =========================================================================
+% DEFINE GRID PROPERTIES
+% =========================================================================
+
+% grid properties
+Nx = 128;
+dx = 0.5e-3;
+Ny = 128;
+dy = 0.5e-3;
+kgrid = kWaveGrid(Nx, dx, Ny, dy);
+
+% medium properties
+medium.sound_speed = 1500;
+
+% time array
+kgrid.makeTime(medium.sound_speed, [], 40e-6);
+
+% =========================================================================
+% SIMULATION WITH GRID-BASED SOURCE
+% =========================================================================
+
+% define positions
+src_x_pos = Nx/2;
+src_y_pos = Ny/2;
+sens_y_offset = Ny/4;
+
+% set source as a disc shaped initial pressure
+source.p0 = makeDisc(Nx, Ny, src_x_pos, src_y_pos, 3);
+
+% define sensor mask
+sensor.mask = zeros(Nx, Ny);
+sensor.mask(src_x_pos, src_y_pos + sens_y_offset) = 1;
+
+% run k-Wave simulation
+sensor_data_on_grid = kspaceFirstOrder2D(kgrid, medium, source, sensor, 'PlotSim', plot_simulations);
+
+% =========================================================================
+% SIMULATION WITH OFF-GRID SOURCE
+% =========================================================================
+
+% create empty array
+karray = kWaveArray();
+
+% add point element
+position = [kgrid.x_vec(src_x_pos), kgrid.y_vec(src_y_pos + sens_y_offset)];
+measure = 1;
+element_dim = 1;
+karray.addCustomElement(position', measure, element_dim, 'Point');
+
+% assign binary mask from karray to the sensor mask
+sensor.mask = karray.getArrayBinaryMask(kgrid);
+
+% run k-Wave simulation
+sensor_data_off_grid = kspaceFirstOrder2D(kgrid, medium, source, sensor, 'PlotSim', plot_simulations);
+
+% combine data to give one trace per physical array element
+sensor_data_off_grid = karray.combineSensorData(kgrid, sensor_data_off_grid);
+
+% compute error
+err = 100 * max(abs(sensor_data_on_grid - sensor_data_off_grid)) / max(sensor_data_on_grid(:));
+
+% check values are the same
+if err > comparison_thresh
+    test_pass = false;
+end
+
+% =========================================================================
+% VISUALISATION
+% =========================================================================
+
+% plot sensor traces
+if plot_comparisons
+    
+    figure;
+    subplot(2, 1, 1);
+    plot(kgrid.t_array, sensor_data_on_grid, 'k-');
+    hold on;
+    plot(kgrid.t_array, sensor_data_off_grid, 'r--');
+    legend('on grid', 'off grid');
+
+    subplot(2, 1, 2);
+    plot(kgrid.t_array, 100 * abs(sensor_data_on_grid - sensor_data_off_grid) ./ max(sensor_data_on_grid(:)), 'k-');
+    ylabel('Error [%]');
+    
+end

--- a/k-Wave/testing/unit/kWaveDiffusion_compare_1D_2D_3D_plane_waves.m
+++ b/k-Wave/testing/unit/kWaveDiffusion_compare_1D_2D_3D_plane_waves.m
@@ -15,10 +15,10 @@ function test_pass = kWaveDiffusion_compare_1D_2D_3D_plane_waves(plot_comparison
 % ABOUT:
 %       author      - Bradley Treeby
 %       date        - 17th August 2015
-%       last update - 25th July 2019
+%       last update - 7th August 2023
 %       
 % This function is part of the k-Wave Toolbox (http://www.k-wave.org)
-% Copyright (C) 2015-2019 Bradley Treeby
+% Copyright (C) 2015-2023 Bradley Treeby
 
 % This file is part of k-Wave. k-Wave is free software: you can
 % redistribute it and/or modify it under the terms of the GNU Lesser
@@ -33,14 +33,17 @@ function test_pass = kWaveDiffusion_compare_1D_2D_3D_plane_waves(plot_comparison
 % You should have received a copy of the GNU Lesser General Public License
 % along with k-Wave. If not, see <http://www.gnu.org/licenses/>.
 
+%#ok<*UNRCH>
+
 % set pass variable
 test_pass = true;
 
 % compare sensor data or final temperature
 compare_sensor_data = false;
 
-% set comparison threshold
-COMPARISON_THRESH   = 1e-13;
+% set comparison thresholds
+COMPARISON_THRESH_DOUBLE = 1e-13;
+COMPARISON_THRESH_SINGLE = 2e-5;
 
 % check for plot inputs, and set to true if nargin is zero (to allow the
 % test to be run independent of runUnitTests)
@@ -79,7 +82,6 @@ source_temp  = 38;
 Q_amp        = 1e5;
 
 % define source profile
-kgrid = kWaveGrid(Nx, dx);
 source_profile = zeros(Nx, 1);
 source_profile(Nx/2) = 1;
 source_profile = smooth(source_profile, true);
@@ -98,404 +100,417 @@ test_names = {...
 	'heterogeneous + perfusion + source.T0', ...
 	'heterogeneous + perfusion + source.Q'};
 
-% loop through tests
-for test_num = 1:8
+% run tests with and without datacasting
+for data_cast_ind = 2:2
 
-    % clear structures
-    clear source medium sensor
-    
-    % update command line
-    disp(['Running Test: ' test_names{test_num}]);
-    
-    % assign medium properties 
-    switch test_num
-        case {1,2}
-            % homog + diffusion
-            medium.density                   = density_1;
-            medium.thermal_conductivity      = thermal_conductivity_1;
-            medium.specific_heat             = specific_heat_1;
-        case {5,6}
-            % homog + perfusion
-            medium.density                   = density_1;
-            medium.thermal_conductivity      = thermal_conductivity_1;
-            medium.specific_heat             = specific_heat_1;
-            medium.perfusion_coeff           = perfusion_coeff_1;
-            medium.blood_ambient_temperature = blood_ambient_temperature_1;
-    end
-    
-    % ----------------
-    % 1D SIMULATION: X
-    % ----------------
-
-    % create computational grid
-    kgrid = kWaveGrid(Nx, dx);
-
-    % define medium if heterog
-    switch test_num
-        case {3,4}
-            % heterog + diffusion
-            medium.density                   = density_1 * ones(Nx, 1);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, 1);
-            medium.specific_heat             = specific_heat_1 * ones(Nx, 1);
-            
-            medium.density(kgrid.x > 0)                 = density_2;
-            medium.thermal_conductivity(kgrid.x > 0)    = thermal_conductivity_2;
-            medium.specific_heat(kgrid.x > 0)           = specific_heat_2;
-        case {7,8}
-            % heterog + perfusion
-            medium.density                   = density_1 * ones(Nx, 1);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, 1);
-            medium.specific_heat             = specific_heat_1 * ones(Nx, 1);
-            medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nx, 1);
-            medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nx, 1);
-            
-            medium.density(kgrid.x > 0)                   = density_2;
-            medium.thermal_conductivity(kgrid.x > 0)      = thermal_conductivity_2;
-            medium.specific_heat(kgrid.x > 0)             = specific_heat_2;
-            medium.perfusion_coeff(kgrid.x > 0)           = perfusion_coeff_2;
-            medium.blood_ambient_temperature(kgrid.x > 0) = blood_ambient_temperature_2;
-    end
-    
-    % source
-    if rem(test_num, 2)
-        source.T0 = ambient_temp + (source_temp - ambient_temp) * source_profile;
-    else
-        source.T0 = ambient_temp;
-        source.Q = Q_amp * source_profile; 
+    switch data_cast_ind
+        case 1
+            comparison_thresh = COMPARISON_THRESH_DOUBLE;
+        case 2
+            comparison_thresh = COMPARISON_THRESH_SINGLE;
+            input_args = [input_args, {'DataCast', 'gpuArray-single'}]; %#ok<AGROW> 
     end
 
-    % define sensor
-    sensor.mask = ones(Nx, 1);
+    % loop through tests
+    for test_num = 1:8
     
-    % run simulation
-    kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
-    kdiff.takeTimeStep(Nt, dt);
+        % clear structures
+        clear source medium sensor
+        
+        % update command line
+        disp(['Running Test: ' test_names{test_num}]);
+        
+        % assign medium properties 
+        switch test_num
+            case {1,2}
+                % homog + diffusion
+                medium.density                   = density_1;
+                medium.thermal_conductivity      = thermal_conductivity_1;
+                medium.specific_heat             = specific_heat_1;
+            case {5,6}
+                % homog + perfusion
+                medium.density                   = density_1;
+                medium.thermal_conductivity      = thermal_conductivity_1;
+                medium.specific_heat             = specific_heat_1;
+                medium.perfusion_coeff           = perfusion_coeff_1;
+                medium.blood_ambient_temperature = blood_ambient_temperature_1;
+        end
+        
+        % ----------------
+        % 1D SIMULATION: X
+        % ----------------
     
-    % assign output data
-    if compare_sensor_data
-        sensor_data_1D = kdiff.sensor_data;
-    else
-        sensor_data_1D = kdiff.T;
+        % create computational grid
+        kgrid = kWaveGrid(Nx, dx);
+    
+        % define medium if heterog
+        switch test_num
+            case {3,4}
+                % heterog + diffusion
+                medium.density                   = density_1 * ones(Nx, 1);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, 1);
+                medium.specific_heat             = specific_heat_1 * ones(Nx, 1);
+                
+                medium.density(kgrid.x > 0)                 = density_2;
+                medium.thermal_conductivity(kgrid.x > 0)    = thermal_conductivity_2;
+                medium.specific_heat(kgrid.x > 0)           = specific_heat_2;
+            case {7,8}
+                % heterog + perfusion
+                medium.density                   = density_1 * ones(Nx, 1);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, 1);
+                medium.specific_heat             = specific_heat_1 * ones(Nx, 1);
+                medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nx, 1);
+                medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nx, 1);
+                
+                medium.density(kgrid.x > 0)                   = density_2;
+                medium.thermal_conductivity(kgrid.x > 0)      = thermal_conductivity_2;
+                medium.specific_heat(kgrid.x > 0)             = specific_heat_2;
+                medium.perfusion_coeff(kgrid.x > 0)           = perfusion_coeff_2;
+                medium.blood_ambient_temperature(kgrid.x > 0) = blood_ambient_temperature_2;
+        end
+        
+        % source
+        if rem(test_num, 2)
+            source.T0 = ambient_temp + (source_temp - ambient_temp) * source_profile;
+        else
+            source.T0 = ambient_temp;
+            source.Q = Q_amp * source_profile; 
+        end
+    
+        % define sensor
+        sensor.mask = ones(Nx, 1);
+        
+        % run simulation
+        kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
+        kdiff.takeTimeStep(Nt, dt);
+        
+        % assign output data
+        if compare_sensor_data
+            sensor_data_1D = kdiff.sensor_data; 
+        else
+            sensor_data_1D = kdiff.T;
+        end
+        
+        % ----------------
+        % 2D SIMULATION: X
+        % ----------------
+    
+        % create computational grid
+        kgrid = kWaveGrid(Nx, dx, Nj, dx);
+    
+        % define medium if heterog
+        switch test_num
+            case {3,4}
+                % heterog + diffusion
+                medium.density                   = density_1 * ones(Nx, Nj);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj);
+                medium.specific_heat             = specific_heat_1 * ones(Nx, Nj);
+                
+                medium.density(kgrid.x > 0)                 = density_2;
+                medium.thermal_conductivity(kgrid.x > 0)    = thermal_conductivity_2;
+                medium.specific_heat(kgrid.x > 0)           = specific_heat_2;
+            case {7,8}
+                % heterog + perfusion
+                medium.density                   = density_1 * ones(Nx, Nj);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj);
+                medium.specific_heat             = specific_heat_1 * ones(Nx, Nj);
+                medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nx, Nj);
+                medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nx, Nj);
+                
+                medium.density(kgrid.x > 0)                   = density_2;
+                medium.thermal_conductivity(kgrid.x > 0)      = thermal_conductivity_2;
+                medium.specific_heat(kgrid.x > 0)             = specific_heat_2;
+                medium.perfusion_coeff(kgrid.x > 0)           = perfusion_coeff_2;
+                medium.blood_ambient_temperature(kgrid.x > 0) = blood_ambient_temperature_2;
+        end    
+        
+        % source
+        if rem(test_num, 2)
+            source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile, [1, Nj]);
+        else
+            source.T0 = ambient_temp;
+            source.Q = Q_amp * repmat(source_profile, [1, Nj]);
+        end
+        
+        % define sensor
+        sensor.mask = zeros(Nx, Nj);    
+        sensor.mask(:, Nj/2) = 1;
+        
+        % run simulation
+        kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
+        kdiff.takeTimeStep(Nt, dt);
+        
+        % assign output data
+        if compare_sensor_data
+            sensor_data_2D_x = kdiff.sensor_data;
+        else
+            sensor_data_2D_x = reshape(kdiff.T(:, Nj/2), [Nx, 1]);
+        end
+        
+        % ----------------
+        % 2D SIMULATION: Y
+        % ----------------
+    
+        % create computational grid
+        kgrid = kWaveGrid(Nj, dx, Nx, dx);
+    
+        % define medium if heterog
+        switch test_num
+            case {3,4}
+                % heterog + diffusion
+                medium.density                   = density_1 * ones(Nj, Nx);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx);
+                medium.specific_heat             = specific_heat_1 * ones(Nj, Nx);
+                
+                medium.density(kgrid.y > 0)                 = density_2;
+                medium.thermal_conductivity(kgrid.y > 0)    = thermal_conductivity_2;
+                medium.specific_heat(kgrid.y > 0)           = specific_heat_2;
+            case {7,8}
+                % heterog + perfusion
+                medium.density                   = density_1 * ones(Nj, Nx);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx);
+                medium.specific_heat             = specific_heat_1 * ones(Nj, Nx);
+                medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nj, Nx);
+                medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nj, Nx);
+                
+                medium.density(kgrid.y > 0)                   = density_2;
+                medium.thermal_conductivity(kgrid.y > 0)      = thermal_conductivity_2;
+                medium.specific_heat(kgrid.y > 0)             = specific_heat_2;
+                medium.perfusion_coeff(kgrid.y > 0)           = perfusion_coeff_2;
+                medium.blood_ambient_temperature(kgrid.y > 0) = blood_ambient_temperature_2;
+        end     
+        
+        % source
+        if rem(test_num, 2)
+            source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile.', [Nj, 1]);
+        else
+            source.T0 = ambient_temp;
+            source.Q = Q_amp * repmat(source_profile.', [Nj, 1]); 
+        end
+        
+        % define sensor
+        sensor.mask = zeros(Nj, Nx);    
+        sensor.mask(Nj/2, :) = 1;    
+        
+         % run simulation
+        kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
+        kdiff.takeTimeStep(Nt, dt);
+        
+        % assign output data
+        if compare_sensor_data
+            sensor_data_2D_y = kdiff.sensor_data;    
+        else
+            sensor_data_2D_y = reshape(kdiff.T(Nj/2, :), [Nx, 1]);
+        end
+    
+        % ----------------
+        % 3D SIMULATION: X
+        % ----------------
+    
+        % create computational grid
+        kgrid = kWaveGrid(Nx, dx, Nj, dx, Nj, dx);
+        
+        % define medium if heterog
+        switch test_num
+            case {3,4}
+                % heterog + diffusion
+                medium.density                   = density_1 * ones(Nx, Nj, Nj);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj, Nj);
+                medium.specific_heat             = specific_heat_1 * ones(Nx, Nj, Nj);
+                
+                medium.density(kgrid.x > 0)                 = density_2;
+                medium.thermal_conductivity(kgrid.x > 0)    = thermal_conductivity_2;
+                medium.specific_heat(kgrid.x > 0)           = specific_heat_2;
+            case {7,8}
+                % heterog + perfusion
+                medium.density                   = density_1 * ones(Nx, Nj, Nj);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj, Nj);
+                medium.specific_heat             = specific_heat_1 * ones(Nx, Nj, Nj);
+                medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nx, Nj, Nj);
+                medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nx, Nj, Nj);
+                
+                medium.density(kgrid.x > 0)                   = density_2;
+                medium.thermal_conductivity(kgrid.x > 0)      = thermal_conductivity_2;
+                medium.specific_heat(kgrid.x > 0)             = specific_heat_2;
+                medium.perfusion_coeff(kgrid.x > 0)           = perfusion_coeff_2;
+                medium.blood_ambient_temperature(kgrid.x > 0) = blood_ambient_temperature_2;
+        end
+        
+        % source
+        if rem(test_num, 2)
+            source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile, [1, Nj, Nj]);
+        else
+            source.T0 = ambient_temp;
+            source.Q = Q_amp * repmat(source_profile, [1, Nj, Nj]);
+        end
+        
+        % define sensor
+        sensor.mask = zeros(Nx, Nj, Nj);    
+        sensor.mask(:, Nj/2, Nj/2) = 1;    
+        
+        % run simulation
+        kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
+        kdiff.takeTimeStep(Nt, dt);
+        
+        % assign output data
+        if compare_sensor_data
+            sensor_data_3D_x = kdiff.sensor_data;
+        else
+            sensor_data_3D_x = reshape(kdiff.T(:, Nj/2, Nj/2), [Nx, 1, 1]);
+        end
+    
+        % ----------------
+        % 3D SIMULATION: Y
+        % ----------------
+    
+        % create computational grid
+        kgrid = kWaveGrid(Nj, dx, Nx, dx, Nj, dx);
+    
+        % define medium if heterog
+        switch test_num
+            case {3,4}
+                % heterog + diffusion
+                medium.density                   = density_1 * ones(Nj, Nx, Nj);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx, Nj);
+                medium.specific_heat             = specific_heat_1 * ones(Nj, Nx, Nj);
+                
+                medium.density(kgrid.y > 0)                 = density_2;
+                medium.thermal_conductivity(kgrid.y > 0)    = thermal_conductivity_2;
+                medium.specific_heat(kgrid.y > 0)           = specific_heat_2;
+            case {7,8}
+                % heterog + perfusion
+                medium.density                   = density_1 * ones(Nj, Nx, Nj);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx, Nj);
+                medium.specific_heat             = specific_heat_1 * ones(Nj, Nx, Nj);
+                medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nj, Nx, Nj);
+                medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nj, Nx, Nj);
+                
+                medium.density(kgrid.y > 0)                   = density_2;
+                medium.thermal_conductivity(kgrid.y > 0)      = thermal_conductivity_2;
+                medium.specific_heat(kgrid.y > 0)             = specific_heat_2;
+                medium.perfusion_coeff(kgrid.y > 0)           = perfusion_coeff_2;
+                medium.blood_ambient_temperature(kgrid.y > 0) = blood_ambient_temperature_2;
+        end    
+        
+        % source
+        if rem(test_num, 2)
+            source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile.', [Nj, 1, Nj]);
+        else
+            source.T0 = ambient_temp;
+            source.Q = Q_amp * repmat(source_profile.', [Nj, 1, Nj]);
+        end
+        
+        % define sensor
+        sensor.mask = zeros(Nj, Nx, Nj);    
+        sensor.mask(Nj/2, :, Nj/2) = 1;    
+        
+        % run simulation
+        kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
+        kdiff.takeTimeStep(Nt, dt);
+        
+        % assign output data
+        if compare_sensor_data
+            sensor_data_3D_y = kdiff.sensor_data;
+        else
+            sensor_data_3D_y = reshape(kdiff.T(Nj/2, :, Nj/2), [Nx, 1, 1]);
+        end
+        
+        % ----------------
+        % 3D SIMULATION: Z
+        % ----------------
+    
+        % create computational grid
+        kgrid = kWaveGrid(Nj, dx, Nj, dx, Nx, dx);
+    
+        % define medium if heterog
+        switch test_num
+            case {3,4}
+                % heterog + diffusion
+                medium.density                   = density_1 * ones(Nj, Nj, Nx);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nj, Nx);
+                medium.specific_heat             = specific_heat_1 * ones(Nj, Nj, Nx);
+                
+                medium.density(kgrid.z > 0)                 = density_2;
+                medium.thermal_conductivity(kgrid.z > 0)    = thermal_conductivity_2;
+                medium.specific_heat(kgrid.z > 0)           = specific_heat_2;
+            case {7,8}
+                % heterog + perfusion
+                medium.density                   = density_1 * ones(Nj, Nj, Nx);
+                medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nj, Nx);
+                medium.specific_heat             = specific_heat_1 * ones(Nj, Nj, Nx);
+                medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nj, Nj, Nx);
+                medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nj, Nj, Nx);
+                
+                medium.density(kgrid.z > 0)                   = density_2;
+                medium.thermal_conductivity(kgrid.z > 0)      = thermal_conductivity_2;
+                medium.specific_heat(kgrid.z > 0)             = specific_heat_2;
+                medium.perfusion_coeff(kgrid.z > 0)           = perfusion_coeff_2;
+                medium.blood_ambient_temperature(kgrid.z > 0) = blood_ambient_temperature_2;
+        end    
+        
+        % source
+        if rem(test_num, 2)
+            source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(reshape(source_profile, [1, 1, Nx]), [Nj, Nj, 1]);
+        else
+            source.T0 = ambient_temp;
+            source.Q = Q_amp * repmat(reshape(source_profile, [1, 1, Nx]), [Nj, Nj, 1]);
+        end
+        
+        % define sensor
+        sensor.mask = zeros(Nj, Nj, Nx);    
+        sensor.mask(Nj/2, Nj/2, :) = 1;    
+        
+        % run simulation
+        kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
+        kdiff.takeTimeStep(Nt, dt);
+        
+        % assign output data
+        if compare_sensor_data
+            sensor_data_3D_z = kdiff.sensor_data;
+        else
+            sensor_data_3D_z = reshape(kdiff.T(Nj/2, Nj/2, :), [Nx, 1, 1]);
+        end
+        
+        % -------------
+        % COMPARISON
+        % -------------
+    
+        diff_1D_2D_x = max(abs(sensor_data_1D(:) - sensor_data_2D_x(:)));
+        diff_1D_2D_y = max(abs(sensor_data_1D(:) - sensor_data_2D_y(:)));
+        diff_1D_3D_x = max(abs(sensor_data_1D(:) - sensor_data_3D_x(:)));
+        diff_1D_3D_y = max(abs(sensor_data_1D(:) - sensor_data_3D_y(:)));
+        diff_1D_3D_z = max(abs(sensor_data_1D(:) - sensor_data_3D_z(:)));
+        
+        if (diff_1D_2D_x > comparison_thresh) || ...
+           (diff_1D_2D_y > comparison_thresh) || ...
+           (diff_1D_3D_x > comparison_thresh) || ...
+           (diff_1D_3D_y > comparison_thresh) || ...
+           (diff_1D_3D_z > comparison_thresh)
+            test_pass = false;
+        end
+        
+        % -------------
+        % PLOTTING
+        % -------------    
+        
+        if plot_comparisons
+            figure;
+            subplot(6, 1, 1), plot(sensor_data_1D);
+            title(['1D (' test_names{test_num} ')']);
+            subplot(6, 1, 2), plot(sensor_data_2D_x);
+            title(['2D X, L_{inf} = ' num2str(diff_1D_2D_x)]);
+            subplot(6, 1, 3), plot(sensor_data_2D_y);
+            title(['2D Y, L_{inf} = ' num2str(diff_1D_2D_y)]);
+            subplot(6, 1, 4), plot(sensor_data_3D_x);
+            title(['3D X, L_{inf} = ' num2str(diff_1D_3D_x)]);
+            subplot(6, 1, 5), plot(sensor_data_3D_y);
+            title(['3D Y, L_{inf} = ' num2str(diff_1D_3D_y)]);
+            subplot(6, 1, 6), plot(sensor_data_3D_z);
+            title(['3D Z, L_{inf} = ' num2str(diff_1D_3D_z)]);
+            scaleFig(1, 1.5);
+            drawnow;
+        end
+        
     end
-    
-    % ----------------
-    % 2D SIMULATION: X
-    % ----------------
 
-    % create computational grid
-    kgrid = kWaveGrid(Nx, dx, Nj, dx);
-
-    % define medium if heterog
-    switch test_num
-        case {3,4}
-            % heterog + diffusion
-            medium.density                   = density_1 * ones(Nx, Nj);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj);
-            medium.specific_heat             = specific_heat_1 * ones(Nx, Nj);
-            
-            medium.density(kgrid.x > 0)                 = density_2;
-            medium.thermal_conductivity(kgrid.x > 0)    = thermal_conductivity_2;
-            medium.specific_heat(kgrid.x > 0)           = specific_heat_2;
-        case {7,8}
-            % heterog + perfusion
-            medium.density                   = density_1 * ones(Nx, Nj);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj);
-            medium.specific_heat             = specific_heat_1 * ones(Nx, Nj);
-            medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nx, Nj);
-            medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nx, Nj);
-            
-            medium.density(kgrid.x > 0)                   = density_2;
-            medium.thermal_conductivity(kgrid.x > 0)      = thermal_conductivity_2;
-            medium.specific_heat(kgrid.x > 0)             = specific_heat_2;
-            medium.perfusion_coeff(kgrid.x > 0)           = perfusion_coeff_2;
-            medium.blood_ambient_temperature(kgrid.x > 0) = blood_ambient_temperature_2;
-    end    
-    
-    % source
-    if rem(test_num, 2)
-        source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile, [1, Nj]);
-    else
-        source.T0 = ambient_temp;
-        source.Q = Q_amp * repmat(source_profile, [1, Nj]);
-    end
-    
-    % define sensor
-    sensor.mask = zeros(Nx, Nj);    
-    sensor.mask(:, Nj/2) = 1;
-    
-    % run simulation
-    kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
-    kdiff.takeTimeStep(Nt, dt);
-    
-    % assign output data
-    if compare_sensor_data
-        sensor_data_2D_x = kdiff.sensor_data;
-    else
-        sensor_data_2D_x = reshape(kdiff.T(:, Nj/2), [Nx, 1]);
-    end
-    
-    % ----------------
-    % 2D SIMULATION: Y
-    % ----------------
-
-    % create computational grid
-    kgrid = kWaveGrid(Nj, dx, Nx, dx);
-
-    % define medium if heterog
-    switch test_num
-        case {3,4}
-            % heterog + diffusion
-            medium.density                   = density_1 * ones(Nj, Nx);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx);
-            medium.specific_heat             = specific_heat_1 * ones(Nj, Nx);
-            
-            medium.density(kgrid.y > 0)                 = density_2;
-            medium.thermal_conductivity(kgrid.y > 0)    = thermal_conductivity_2;
-            medium.specific_heat(kgrid.y > 0)           = specific_heat_2;
-        case {7,8}
-            % heterog + perfusion
-            medium.density                   = density_1 * ones(Nj, Nx);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx);
-            medium.specific_heat             = specific_heat_1 * ones(Nj, Nx);
-            medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nj, Nx);
-            medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nj, Nx);
-            
-            medium.density(kgrid.y > 0)                   = density_2;
-            medium.thermal_conductivity(kgrid.y > 0)      = thermal_conductivity_2;
-            medium.specific_heat(kgrid.y > 0)             = specific_heat_2;
-            medium.perfusion_coeff(kgrid.y > 0)           = perfusion_coeff_2;
-            medium.blood_ambient_temperature(kgrid.y > 0) = blood_ambient_temperature_2;
-    end     
-    
-    % source
-    if rem(test_num, 2)
-        source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile.', [Nj, 1]);
-    else
-        source.T0 = ambient_temp;
-        source.Q = Q_amp * repmat(source_profile.', [Nj, 1]); 
-    end
-    
-    % define sensor
-    sensor.mask = zeros(Nj, Nx);    
-    sensor.mask(Nj/2, :) = 1;    
-    
-     % run simulation
-    kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
-    kdiff.takeTimeStep(Nt, dt);
-    
-    % assign output data
-    if compare_sensor_data
-        sensor_data_2D_y = kdiff.sensor_data;    
-    else
-        sensor_data_2D_y = reshape(kdiff.T(Nj/2, :), [Nx, 1]);
-    end
-
-    % ----------------
-    % 3D SIMULATION: X
-    % ----------------
-
-    % create computational grid
-    kgrid = kWaveGrid(Nx, dx, Nj, dx, Nj, dx);
-    
-    % define medium if heterog
-    switch test_num
-        case {3,4}
-            % heterog + diffusion
-            medium.density                   = density_1 * ones(Nx, Nj, Nj);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj, Nj);
-            medium.specific_heat             = specific_heat_1 * ones(Nx, Nj, Nj);
-            
-            medium.density(kgrid.x > 0)                 = density_2;
-            medium.thermal_conductivity(kgrid.x > 0)    = thermal_conductivity_2;
-            medium.specific_heat(kgrid.x > 0)           = specific_heat_2;
-        case {7,8}
-            % heterog + perfusion
-            medium.density                   = density_1 * ones(Nx, Nj, Nj);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nx, Nj, Nj);
-            medium.specific_heat             = specific_heat_1 * ones(Nx, Nj, Nj);
-            medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nx, Nj, Nj);
-            medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nx, Nj, Nj);
-            
-            medium.density(kgrid.x > 0)                   = density_2;
-            medium.thermal_conductivity(kgrid.x > 0)      = thermal_conductivity_2;
-            medium.specific_heat(kgrid.x > 0)             = specific_heat_2;
-            medium.perfusion_coeff(kgrid.x > 0)           = perfusion_coeff_2;
-            medium.blood_ambient_temperature(kgrid.x > 0) = blood_ambient_temperature_2;
-    end
-    
-    % source
-    if rem(test_num, 2)
-        source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile, [1, Nj, Nj]);
-    else
-        source.T0 = ambient_temp;
-        source.Q = Q_amp * repmat(source_profile, [1, Nj, Nj]);
-    end
-    
-    % define sensor
-    sensor.mask = zeros(Nx, Nj, Nj);    
-    sensor.mask(:, Nj/2, Nj/2) = 1;    
-    
-    % run simulation
-    kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
-    kdiff.takeTimeStep(Nt, dt);
-    
-    % assign output data
-    if compare_sensor_data
-        sensor_data_3D_x = kdiff.sensor_data;
-    else
-        sensor_data_3D_x = reshape(kdiff.T(:, Nj/2, Nj/2), [Nx, 1, 1]);
-    end
-
-    % ----------------
-    % 3D SIMULATION: Y
-    % ----------------
-
-    % create computational grid
-    kgrid = kWaveGrid(Nj, dx, Nx, dx, Nj, dx);
-
-    % define medium if heterog
-    switch test_num
-        case {3,4}
-            % heterog + diffusion
-            medium.density                   = density_1 * ones(Nj, Nx, Nj);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx, Nj);
-            medium.specific_heat             = specific_heat_1 * ones(Nj, Nx, Nj);
-            
-            medium.density(kgrid.y > 0)                 = density_2;
-            medium.thermal_conductivity(kgrid.y > 0)    = thermal_conductivity_2;
-            medium.specific_heat(kgrid.y > 0)           = specific_heat_2;
-        case {7,8}
-            % heterog + perfusion
-            medium.density                   = density_1 * ones(Nj, Nx, Nj);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nx, Nj);
-            medium.specific_heat             = specific_heat_1 * ones(Nj, Nx, Nj);
-            medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nj, Nx, Nj);
-            medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nj, Nx, Nj);
-            
-            medium.density(kgrid.y > 0)                   = density_2;
-            medium.thermal_conductivity(kgrid.y > 0)      = thermal_conductivity_2;
-            medium.specific_heat(kgrid.y > 0)             = specific_heat_2;
-            medium.perfusion_coeff(kgrid.y > 0)           = perfusion_coeff_2;
-            medium.blood_ambient_temperature(kgrid.y > 0) = blood_ambient_temperature_2;
-    end    
-    
-    % source
-    if rem(test_num, 2)
-        source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(source_profile.', [Nj, 1, Nj]);
-    else
-        source.T0 = ambient_temp;
-        source.Q = Q_amp * repmat(source_profile.', [Nj, 1, Nj]);
-    end
-    
-    % define sensor
-    sensor.mask = zeros(Nj, Nx, Nj);    
-    sensor.mask(Nj/2, :, Nj/2) = 1;    
-    
-    % run simulation
-    kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
-    kdiff.takeTimeStep(Nt, dt);
-    
-    % assign output data
-    if compare_sensor_data
-        sensor_data_3D_y = kdiff.sensor_data;
-    else
-        sensor_data_3D_y = reshape(kdiff.T(Nj/2, :, Nj/2), [Nx, 1, 1]);
-    end
-    
-    % ----------------
-    % 3D SIMULATION: Z
-    % ----------------
-
-    % create computational grid
-    kgrid = kWaveGrid(Nj, dx, Nj, dx, Nx, dx);
-
-    % define medium if heterog
-    switch test_num
-        case {3,4}
-            % heterog + diffusion
-            medium.density                   = density_1 * ones(Nj, Nj, Nx);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nj, Nx);
-            medium.specific_heat             = specific_heat_1 * ones(Nj, Nj, Nx);
-            
-            medium.density(kgrid.z > 0)                 = density_2;
-            medium.thermal_conductivity(kgrid.z > 0)    = thermal_conductivity_2;
-            medium.specific_heat(kgrid.z > 0)           = specific_heat_2;
-        case {7,8}
-            % heterog + perfusion
-            medium.density                   = density_1 * ones(Nj, Nj, Nx);
-            medium.thermal_conductivity      = thermal_conductivity_1 * ones(Nj, Nj, Nx);
-            medium.specific_heat             = specific_heat_1 * ones(Nj, Nj, Nx);
-            medium.perfusion_coeff           = perfusion_coeff_1 * ones(Nj, Nj, Nx);
-            medium.blood_ambient_temperature = blood_ambient_temperature_1 * ones(Nj, Nj, Nx);
-            
-            medium.density(kgrid.z > 0)                   = density_2;
-            medium.thermal_conductivity(kgrid.z > 0)      = thermal_conductivity_2;
-            medium.specific_heat(kgrid.z > 0)             = specific_heat_2;
-            medium.perfusion_coeff(kgrid.z > 0)           = perfusion_coeff_2;
-            medium.blood_ambient_temperature(kgrid.z > 0) = blood_ambient_temperature_2;
-    end    
-    
-    % source
-    if rem(test_num, 2)
-        source.T0 = ambient_temp + (source_temp - ambient_temp) * repmat(reshape(source_profile, [1, 1, Nx]), [Nj, Nj, 1]);
-    else
-        source.T0 = ambient_temp;
-        source.Q = Q_amp * repmat(reshape(source_profile, [1, 1, Nx]), [Nj, Nj, 1]);
-    end
-    
-    % define sensor
-    sensor.mask = zeros(Nj, Nj, Nx);    
-    sensor.mask(Nj/2, Nj/2, :) = 1;    
-    
-    % run simulation
-    kdiff = kWaveDiffusion(kgrid, medium, source, sensor, input_args{:});
-    kdiff.takeTimeStep(Nt, dt);
-    
-    % assign output data
-    if compare_sensor_data
-        sensor_data_3D_z = kdiff.sensor_data;
-    else
-        sensor_data_3D_z = reshape(kdiff.T(Nj/2, Nj/2, :), [Nx, 1, 1]);
-    end
-    
-    % -------------
-    % COMPARISON
-    % -------------
-
-    diff_1D_2D_x = max(abs(sensor_data_1D(:) - sensor_data_2D_x(:)));
-    diff_1D_2D_y = max(abs(sensor_data_1D(:) - sensor_data_2D_y(:)));
-    diff_1D_3D_x = max(abs(sensor_data_1D(:) - sensor_data_3D_x(:)));
-    diff_1D_3D_y = max(abs(sensor_data_1D(:) - sensor_data_3D_y(:)));
-    diff_1D_3D_z = max(abs(sensor_data_1D(:) - sensor_data_3D_z(:)));
-    
-    if (diff_1D_2D_x > COMPARISON_THRESH) || ...
-       (diff_1D_2D_y > COMPARISON_THRESH) || ...
-       (diff_1D_3D_x > COMPARISON_THRESH) || ...
-       (diff_1D_3D_y > COMPARISON_THRESH) || ...
-       (diff_1D_3D_z > COMPARISON_THRESH)
-        test_pass = false;
-    end
-    
-    % -------------
-    % PLOTTING
-    % -------------    
-    
-    if plot_comparisons
-        figure;
-        subplot(6, 1, 1), plot(sensor_data_1D);
-        title(['1D (' test_names{test_num} ')']);
-        subplot(6, 1, 2), plot(sensor_data_2D_x);
-        title(['2D X, L_{inf} = ' num2str(diff_1D_2D_x)]);
-        subplot(6, 1, 3), plot(sensor_data_2D_y);
-        title(['2D Y, L_{inf} = ' num2str(diff_1D_2D_y)]);
-        subplot(6, 1, 4), plot(sensor_data_3D_x);
-        title(['3D X, L_{inf} = ' num2str(diff_1D_3D_x)]);
-        subplot(6, 1, 5), plot(sensor_data_3D_y);
-        title(['3D Y, L_{inf} = ' num2str(diff_1D_3D_y)]);
-        subplot(6, 1, 6), plot(sensor_data_3D_z);
-        title(['3D Z, L_{inf} = ' num2str(diff_1D_3D_z)]);
-        scaleFig(1, 1.5);
-        drawnow;
-    end
-    
 end

--- a/k-Wave/testing/unit/kWaveDiffusion_compare_3D_heterog_perfusion_with_exact.m
+++ b/k-Wave/testing/unit/kWaveDiffusion_compare_3D_heterog_perfusion_with_exact.m
@@ -6,10 +6,10 @@ function test_pass = kWaveDiffusion_compare_3D_heterog_perfusion_with_exact(plot
 % ABOUT:
 %       author      - Bradley Treeby
 %       date        - 16th August 2015
-%       last update - 25th July 2019
+%       last update - 7th August 2023
 %       
 % This function is part of the k-Wave Toolbox (http://www.k-wave.org)
-% Copyright (C) 2015-2019 Bradley Treeby
+% Copyright (C) 2015-2023 Bradley Treeby
 
 % This file is part of k-Wave. k-Wave is free software: you can
 % redistribute it and/or modify it under the terms of the GNU Lesser
@@ -28,7 +28,7 @@ function test_pass = kWaveDiffusion_compare_3D_heterog_perfusion_with_exact(plot
 test_pass = true;
 
 % set comparison threshold
-COMPARISON_THRESH = 1e-5;
+COMPARISON_THRESH = 3e-5;
 
 % check for plot inputs, and set to true if nargin is zero (to allow the
 % test to be run independent of runUnitTests)
@@ -37,244 +37,256 @@ if nargin == 0
     plot_simulations = true;
 end
 
-% =========================================================================
-% SIMULATION
-% =========================================================================
+% run the whole test twice, once with the 'DataCast' option
+for test_ind = 1:2
 
-% create grid
-Nx = 64;
-Ny = 64;
-Nz = 64;
-dx = 1e-3;
-dy = 1e-3;
-dz = 1e-3;
-kgrid = kWaveGrid(Nx, dx, Ny, dy, Nz, dz);
+    clear kgrid medium source
 
-% define medium properties
-density_1              = 1079;  % [kg/m^3]
-thermal_conductivity_1 = 0.52;  % [W/(m.K)]
-specific_heat_1        = 3540;  % [J/(kg.K)]
-
-density_2              = 1200;  % [kg/m^3]
-thermal_conductivity_2 = 0.13;  % [W/(m.K)]
-specific_heat_2        = 4000;  % [J/(kg.K)]
-
-% define blood properties
-blood_density          = 1060;  % [kg/m^3]
-blood_specific_heat    = 3617;  % [J/(kg.K)]
-blood_ambient_temp     = 37;    % [degC]
-blood_perfusion_rate_1 = 0.005;  % [1/s]
-blood_perfusion_rate_2 = 0.02;  % [1/s]
-
-% calculate perfusion
-perfusion_coeff_1 = (blood_density .* blood_perfusion_rate_1 .* blood_specific_heat) ./ (density_1 .* specific_heat_1);
-perfusion_coeff_2 = (blood_density .* blood_perfusion_rate_2 .* blood_specific_heat) ./ (density_2 .* specific_heat_2);
-
-% define heterogeneous medium properties
-medium.density              = density_1 .* ones(Nx, Ny, Nz);
-medium.thermal_conductivity = thermal_conductivity_1 .* ones(Nx, Ny, Nz);
-medium.specific_heat        = specific_heat_1 .* ones(Nx, Ny, Nz);
-medium.perfusion_coeff      = perfusion_coeff_1 .* ones(Nx, Ny, Nz);
-
-medium.density(kgrid.y > 0)              = density_2;
-medium.thermal_conductivity(kgrid.y > 0) = thermal_conductivity_2;
-medium.specific_heat(kgrid.y > 0)        = specific_heat_2;
-medium.perfusion_coeff(kgrid.y > 0)      = perfusion_coeff_2;
-
-% define arterial temperature
-medium.blood_ambient_temperature = blood_ambient_temp;     	% [degC]
-
-% set initial temperature distribution
-s1 = smooth(makeBall(Nx, Ny, Nz, Nx/2, Ny/4, Nz/2, 3));
-s2 = smooth(makeBall(Nx, Ny, Nz, Nx/2, 3*Ny/4, Nz/2, 3));
-
-% define source term
-source.T0  = 37 + s1 + s2;
-
-% set number of time steps
-Nt = 75;
-dt = 0.5;
-
-% set input args
-input_args = {'PlotSim', plot_simulations, 'PlotScale', [37, 38]};
-
-% create kWaveDiffusion object and take time steps
-medium.diffusion_coeff_ref = 'max';
-medium.perfusion_coeff_ref = 'min';
-kdiff_max = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
-kdiff_max.takeTimeStep(Nt, dt);
-
-% create kWaveDiffusion object again using opposite reference value and
-% take time steps 
-medium.diffusion_coeff_ref = 'min';
-medium.perfusion_coeff_ref = 'max';
-kdiff_min = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
-kdiff_min.takeTimeStep(Nt, dt);
-
-% compare with Green's function solution
-D1  = thermal_conductivity_1 / (density_1 * specific_heat_1);
-P1  = blood_density * blood_specific_heat * blood_perfusion_rate_1 / (density_1 * specific_heat_1);
-T_exact1 = bioheatExact(37 + s1, 0, [D1, P1, blood_ambient_temp], kgrid.dx, Nt*dt);
-
-D2  = thermal_conductivity_2 / (density_2 * specific_heat_2);
-P2  = blood_density * blood_specific_heat * blood_perfusion_rate_2 / (density_2 * specific_heat_2);
-T_exact2 = bioheatExact(37 + s2, 0, [D2, P2, blood_ambient_temp], kgrid.dx, Nt*dt);
-
-T_exact = zeros(Nx, Ny, Nz);
-T_exact(:, 1:Ny/2, :)     = T_exact1(:, 1:Ny/2, :);
-T_exact(:, Ny/2+1:end, :) = T_exact2(:, Ny/2+1:end, :);
-
-% calculate error
-error_max = abs(kdiff_max.T - T_exact);
-error_min = abs(kdiff_min.T - T_exact);
-
-% error using the exact solution for each side
-error_best = [error_max(:, 1:Ny/2, :), error_min(:, Ny/2+1:end, :)];
-
-% compute the maximum error
-L_inf = max(error_best(:));
-
-% compute pass
-if (L_inf > COMPARISON_THRESH)
-    test_pass = false;
-end
-
-% =========================================================================
-% PLOT COMPARISONS
-% =========================================================================
-
-if plot_comparisons
-
-    figure;
+    % =====================================================================
+    % SIMULATION
+    % =====================================================================
     
-    subplot(2, 3, 1);
-    imagesc(squeeze(kdiff_max.T(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('k-Wave with Dref max (matches left side)');
-
-    subplot(2, 3, 2);
-    imagesc(squeeze(kdiff_min.T(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('k-Wave with Dref min (matches right side)');    
+    % create grid
+    Nx = 64;
+    Ny = 64;
+    Nz = 64;
+    dx = 1e-3;
+    dy = 1e-3;
+    dz = 1e-3;
+    kgrid = kWaveGrid(Nx, dx, Ny, dy, Nz, dz);
     
-    subplot(2, 3, 3);
-    imagesc(squeeze(T_exact(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Exact solution');
-
-    subplot(2, 3, 4);
-    imagesc(squeeze(error_max(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Error with Dref max');
-
-    subplot(2, 3, 5);
-    imagesc(squeeze(error_min(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Error with Dref min');
+    % define medium properties
+    density_1              = 1079;  % [kg/m^3]
+    thermal_conductivity_1 = 0.52;  % [W/(m.K)]
+    specific_heat_1        = 3540;  % [J/(kg.K)]
     
-    subplot(2, 3, 6);
-    imagesc(squeeze(error_best(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Error with correct ref for each half');  
+    density_2              = 1200;  % [kg/m^3]
+    thermal_conductivity_2 = 0.13;  % [W/(m.K)]
+    specific_heat_2        = 4000;  % [J/(kg.K)]
     
-end
-
-% =========================================================================
-% SIMULATION - SOURCE
-% =========================================================================
-
-% set Gaussian heat source
-x_offset = 15e-3;
-y_offset = 15e-3;
-z_offset = 0;
-width = 3*dx;
-source.Q = 3e4 * exp(-( ((kgrid.x-x_offset)/width).^2 + ((kgrid.y-y_offset)/width).^2 + ((kgrid.z-z_offset)/width).^2 ));
-
-% create kWaveDiffusion object and take time steps
-medium.diffusion_coeff_ref = 'max';
-medium.perfusion_coeff_ref = 'min';
-kdiff_max = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
-kdiff_max.takeTimeStep(Nt, dt);
-
-% create kWaveDiffusion object again using opposite reference value and
-% take time steps 
-medium.diffusion_coeff_ref = 'min';
-medium.perfusion_coeff_ref = 'max';
-kdiff_min = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
-kdiff_min.takeTimeStep(Nt, dt);
-
-% compare with Green's function solution
-S = source.Q ./ (medium.density .* medium.specific_heat);
-T_exact1 = bioheatExact(37 + s1, S, [D1, P1, blood_ambient_temp], kgrid.dx, Nt*dt);
-T_exact2 = bioheatExact(37 + s2, S, [D2, P2, blood_ambient_temp], kgrid.dx, Nt*dt);
-
-T_exact = zeros(Nx, Ny, Nz);
-T_exact(:, 1:Ny/2, :)     = T_exact1(:, 1:Ny/2, :);
-T_exact(:, Ny/2+1:end, :) = T_exact2(:, Ny/2+1:end, :);
-
-% calculate error
-error_max = abs(kdiff_max.T - T_exact);
-error_min = abs(kdiff_min.T - T_exact);
-
-% error using the exact solution for each side
-error_best = [error_max(:, 1:Ny/2, :), error_min(:, Ny/2+1:end, :)];
-
-% compute the maximum error
-L_inf = max(error_best(:));
-
-% compute pass
-if (L_inf > COMPARISON_THRESH)
-    test_pass = false;
-end
-
-% =========================================================================
-% PLOT COMPARISONS
-% =========================================================================
-
-if plot_comparisons
-
-    figure;
+    % define blood properties
+    blood_density          = 1060;  % [kg/m^3]
+    blood_specific_heat    = 3617;  % [J/(kg.K)]
+    blood_ambient_temp     = 37;    % [degC]
+    blood_perfusion_rate_1 = 0.005;  % [1/s]
+    blood_perfusion_rate_2 = 0.02;  % [1/s]
     
-    subplot(2, 3, 1);
-    imagesc(squeeze(kdiff_max.T(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('k-Wave with Dref max (matches left side)');
-
-    subplot(2, 3, 2);
-    imagesc(squeeze(kdiff_min.T(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('k-Wave with Dref min (matches right side)');    
+    % calculate perfusion
+    perfusion_coeff_1 = (blood_density .* blood_perfusion_rate_1 .* blood_specific_heat) ./ (density_1 .* specific_heat_1);
+    perfusion_coeff_2 = (blood_density .* blood_perfusion_rate_2 .* blood_specific_heat) ./ (density_2 .* specific_heat_2);
     
-    subplot(2, 3, 3);
-    imagesc(squeeze(T_exact(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Exact solution');
-
-    subplot(2, 3, 4);
-    imagesc(squeeze(error_max(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Error with Dref max');
-
-    subplot(2, 3, 5);
-    imagesc(squeeze(error_min(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Error with Dref min');
+    % define heterogeneous medium properties
+    medium.density              = density_1 .* ones(Nx, Ny, Nz);
+    medium.thermal_conductivity = thermal_conductivity_1 .* ones(Nx, Ny, Nz);
+    medium.specific_heat        = specific_heat_1 .* ones(Nx, Ny, Nz);
+    medium.perfusion_coeff      = perfusion_coeff_1 .* ones(Nx, Ny, Nz);
     
-    subplot(2, 3, 6);
-    imagesc(squeeze(error_best(:, :, Nz/2)));
-    axis image;
-    colorbar;
-    title('Error with correct ref for each half');  
+    medium.density(kgrid.y > 0)              = density_2;
+    medium.thermal_conductivity(kgrid.y > 0) = thermal_conductivity_2;
+    medium.specific_heat(kgrid.y > 0)        = specific_heat_2;
+    medium.perfusion_coeff(kgrid.y > 0)      = perfusion_coeff_2;
     
+    % define arterial temperature
+    medium.blood_ambient_temperature = blood_ambient_temp;     	% [degC]
+    
+    % set initial temperature distribution
+    s1 = smooth(makeBall(Nx, Ny, Nz, Nx/2, Ny/4, Nz/2, 3));
+    s2 = smooth(makeBall(Nx, Ny, Nz, Nx/2, 3*Ny/4, Nz/2, 3));
+    
+    % define source term
+    source.T0  = 37 + s1 + s2;
+    
+    % set number of time steps
+    Nt = 75;
+    dt = 0.5;
+    
+    % set input args
+    switch test_ind
+        case 1
+            input_args = {'PlotSim', plot_simulations, 'PlotScale', [37, 38]};
+        case 2
+            input_args = {'PlotSim', plot_simulations, 'PlotScale', [37, 38], 'DataCast', 'gpuArray-single'};
+    end
+    
+    % create kWaveDiffusion object and take time steps
+    medium.diffusion_coeff_ref = 'max';
+    medium.perfusion_coeff_ref = 'min';
+    kdiff_max = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
+    kdiff_max.takeTimeStep(Nt, dt);
+    
+    % create kWaveDiffusion object again using opposite reference value and
+    % take time steps 
+    medium.diffusion_coeff_ref = 'min';
+    medium.perfusion_coeff_ref = 'max';
+    kdiff_min = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
+    kdiff_min.takeTimeStep(Nt, dt);
+    
+    % compare with Green's function solution
+    D1  = thermal_conductivity_1 / (density_1 * specific_heat_1);
+    P1  = blood_density * blood_specific_heat * blood_perfusion_rate_1 / (density_1 * specific_heat_1);
+    T_exact1 = bioheatExact(37 + s1, 0, [D1, P1, blood_ambient_temp], kgrid.dx, Nt*dt);
+    
+    D2  = thermal_conductivity_2 / (density_2 * specific_heat_2);
+    P2  = blood_density * blood_specific_heat * blood_perfusion_rate_2 / (density_2 * specific_heat_2);
+    T_exact2 = bioheatExact(37 + s2, 0, [D2, P2, blood_ambient_temp], kgrid.dx, Nt*dt);
+    
+    T_exact = zeros(Nx, Ny, Nz);
+    T_exact(:, 1:Ny/2, :)     = T_exact1(:, 1:Ny/2, :);
+    T_exact(:, Ny/2+1:end, :) = T_exact2(:, Ny/2+1:end, :);
+    
+    % calculate error
+    error_max = abs(kdiff_max.T - T_exact);
+    error_min = abs(kdiff_min.T - T_exact);
+    
+    % error using the exact solution for each side
+    error_best = [error_max(:, 1:Ny/2, :), error_min(:, Ny/2+1:end, :)];
+    
+    % compute the maximum error
+    L_inf = max(error_best(:));
+    
+    % compute pass
+    if (L_inf > COMPARISON_THRESH)
+        test_pass = false;
+    end
+    
+    % =====================================================================
+    % PLOT COMPARISONS
+    % =====================================================================
+    
+    if plot_comparisons
+    
+        figure;
+        
+        subplot(2, 3, 1);
+        imagesc(squeeze(kdiff_max.T(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('k-Wave with Dref max (matches left side)');
+    
+        subplot(2, 3, 2);
+        imagesc(squeeze(kdiff_min.T(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('k-Wave with Dref min (matches right side)');    
+        
+        subplot(2, 3, 3);
+        imagesc(squeeze(T_exact(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Exact solution');
+    
+        subplot(2, 3, 4);
+        imagesc(squeeze(error_max(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Error with Dref max');
+    
+        subplot(2, 3, 5);
+        imagesc(squeeze(error_min(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Error with Dref min');
+        
+        subplot(2, 3, 6);
+        imagesc(squeeze(error_best(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Error with correct ref for each half');  
+        
+    end
+    
+    % =====================================================================
+    % SIMULATION - SOURCE
+    % =====================================================================
+    
+    % set Gaussian heat source
+    x_offset = 15e-3;
+    y_offset = 15e-3;
+    z_offset = 0;
+    width = 3*dx;
+    source.Q = 3e4 * exp(-( ((kgrid.x-x_offset)/width).^2 + ((kgrid.y-y_offset)/width).^2 + ((kgrid.z-z_offset)/width).^2 ));
+    
+    % create kWaveDiffusion object and take time steps
+    medium.diffusion_coeff_ref = 'max';
+    medium.perfusion_coeff_ref = 'min';
+    kdiff_max = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
+    kdiff_max.takeTimeStep(Nt, dt);
+    
+    % create kWaveDiffusion object again using opposite reference value and
+    % take time steps 
+    medium.diffusion_coeff_ref = 'min';
+    medium.perfusion_coeff_ref = 'max';
+    kdiff_min = kWaveDiffusion(kgrid, medium, source, [], input_args{:});
+    kdiff_min.takeTimeStep(Nt, dt);
+    
+    % compare with Green's function solution
+    S = source.Q ./ (medium.density .* medium.specific_heat);
+    T_exact1 = bioheatExact(37 + s1, S, [D1, P1, blood_ambient_temp], kgrid.dx, Nt*dt);
+    T_exact2 = bioheatExact(37 + s2, S, [D2, P2, blood_ambient_temp], kgrid.dx, Nt*dt);
+    
+    T_exact = zeros(Nx, Ny, Nz);
+    T_exact(:, 1:Ny/2, :)     = T_exact1(:, 1:Ny/2, :);
+    T_exact(:, Ny/2+1:end, :) = T_exact2(:, Ny/2+1:end, :);
+    
+    % calculate error
+    error_max = abs(kdiff_max.T - T_exact);
+    error_min = abs(kdiff_min.T - T_exact);
+    
+    % error using the exact solution for each side
+    error_best = [error_max(:, 1:Ny/2, :), error_min(:, Ny/2+1:end, :)];
+    
+    % compute the maximum error
+    L_inf = max(error_best(:));
+    
+    % compute pass
+    if (L_inf > COMPARISON_THRESH)
+        test_pass = false;
+    end
+    
+    % =====================================================================
+    % PLOT COMPARISONS
+    % =====================================================================
+    
+    if plot_comparisons
+    
+        figure;
+        
+        subplot(2, 3, 1);
+        imagesc(squeeze(kdiff_max.T(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('k-Wave with Dref max (matches left side)');
+    
+        subplot(2, 3, 2);
+        imagesc(squeeze(kdiff_min.T(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('k-Wave with Dref min (matches right side)');    
+        
+        subplot(2, 3, 3);
+        imagesc(squeeze(T_exact(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Exact solution');
+    
+        subplot(2, 3, 4);
+        imagesc(squeeze(error_max(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Error with Dref max');
+    
+        subplot(2, 3, 5);
+        imagesc(squeeze(error_min(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Error with Dref min');
+        
+        subplot(2, 3, 6);
+        imagesc(squeeze(error_best(:, :, Nz/2)));
+        axis image;
+        colorbar;
+        title('Error with correct ref for each half');  
+        
+    end
+
 end

--- a/k-Wave/testing/unit/kWaveDiffusion_compare_with_pde.m
+++ b/k-Wave/testing/unit/kWaveDiffusion_compare_with_pde.m
@@ -31,7 +31,7 @@ end
 
 % check for dtt functions
 if ~exist('dtt1D', 'file') 
-    disp('WARNING: kWaveDiffusion_test_boundary_conditions_2D not tested, as dtt library is not present on path');
+    disp('WARNING: kWaveDiffusion_compare_with_pde not tested, as dtt library is not present on path');
     return
 end
 


### PR DESCRIPTION
## Description

Adds the `DataCast` option to `kWaveDiffusion` to allow thermal simulations to be run on the GPU.

Closes #2 

## Testing

Extended the following tests to include the `DataCast` option
- `testing/unit/kWaveDiffusion_compare_1D_2D_3D_plane_waves.m`
- `testing/unit/kWaveDiffusion_compare_3D_heterog_perfusion_with_exact.m`

Unit and regression tests pass on Windows 10 (MATLAB 2022a) and unit tests pass on Ubuntu Linux 22.04.3 (MATLAB 2021a).