### PR TITLE
Bug fix: support 'line' elements in kWaveArray plotting

### DIFF
--- a/k-Wave/kWaveArray.m
+++ b/k-Wave/kWaveArray.m
@@ -1409,7 +1409,15 @@ classdef kWaveArray < handle
                         
                         % plot
                         plot(arc(2, :), arc(1, :), '-', 'Color', obj.element_plot_colour);
-                        
+                    
+                    case 'line'
+                        coords = [obj.elements{element_num}.start_point; obj.elements{element_num}.end_point]';
+                        switch size(coords, 1)
+                            case 1, plot(coords, [0 0], '-', 'Color', obj.element_plot_colour, 'LineWidth', 2);
+                            case 2, plot(coords(1,:), coords(2,:), '-', 'Color', obj.element_plot_colour, 'LineWidth', 2);
+                            case 3, plot3(coords(1,:), coords(2,:), coords(3,:), '-', 'Color', obj.element_plot_colour, 'LineWidth', 2);
+                        end
+                                             
                     otherwise
                         error([obj.elements{element_num}.type ' is not a valid array element type.']);
                 end


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for plotting line elements in the `plotArray` method of the `kWaveArray` class. Previously, attempting to plot a line element resulted in an error due to unsupported element type. The new code handles the 'line' case.

It can be tested with the following code:
```
karray=kWaveArray;
karray.addLineElement([1,1,1], [2,3,4]);
karray.plotArray;
```
This should result in the following Figure:
<img width="150" alt="Figure_1" src="https://github.com/user-attachments/assets/04876bb3-ad1d-411c-b3fc-22e6cd10a2b8" />

I also checked plotting for other accepted dimensional inputs for `start_point` and `end_point`, i.e. 1D: `[x]`,  2D:` [x, y]`.

Fixes #4  Bug: kWaveArray support for plotting line elements 🐛

**Notes**
Note that the CI is working! 🎉 