### PR TITLE
Bug fix: alpha_power input checking

### DIFF
--- a/k-Wave/private/kspaceFirstOrder_inputChecking.m
+++ b/k-Wave/private/kspaceFirstOrder_inputChecking.m
@@ -213,7 +213,7 @@ if isfield(medium, 'alpha_coeff') || isfield(medium, 'alpha_power')
         end
 
         % check y is real and within 0 to 3
-        if ~isreal(medium.alpha_coeff) || (medium.alpha_power >= 3 || medium.alpha_power < 0)
+        if ~isreal(medium.alpha_power) || (medium.alpha_power >= 3 || medium.alpha_power < 0)
             error('medium.alpha_power must be a real number between 0 and 3.');
         end
 


### PR DESCRIPTION
**What does this PR do?**

Fixes #15 Bug: input checking gives misleading message  🐛

`medium.alpha_coeff` was incorrectly checked in `kspaceFirstOrder_inputChecking `instead of `medium.alpha_power`, as pointed out by @cldonovan.

After the bug fix, the correct error message was displayed when `medium.alpha_coeff` was set to an invalid value, verified by running an example with altered  `medium.alpha_coeff`  both before and after the fix.

Thanks to @cldonovan for spotting the issue and suggesting the correct fix! 🚀✨ 