### PR TITLE
Improve CI output

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("kWaveDiffusion_compare_3D_heterog",false);
+            test_struct = runUnitTests("",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,16 +27,6 @@ jobs:
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 
-      - name: Show test results 
-        uses: matlab-actions/run-command@v2
-        with:
-          command: |
-            addpath("${{ github.workspace }}/k-Wave");
-            cd("${{ github.workspace }}/k-Wave/testing/unit");
-            load('test_struct.mat', 'test_struct');
-            runUnitTests_show_results(test_struct);
-          startup-options: -nojvm 
-
       - name: Create artifact
         uses: matlab-actions/run-command@v2
         with:
@@ -52,3 +42,14 @@ jobs:
         with:
           name: unit_test_results
           path: ${{ github.workspace }}/k-Wave/testing/unit/test_results.json
+
+      - name: Test results 
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            addpath("${{ github.workspace }}/k-Wave");
+            cd("${{ github.workspace }}/k-Wave/testing/unit");
+            load('test_struct.mat', 'test_struct');
+            runUnitTests_show_results(test_struct);
+          startup-options: -nojvm 
+

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,6 +2,11 @@ name: Run unit tests
 
 on:
   push:
+    branches:
+       - main
+  pull_request:
+    branches:
+       - main
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("save",false);
+            test_struct = runUnitTests("",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,11 +2,6 @@ name: Run unit tests
 
 on:
   push:
-    branches:
-       - main
-  pull_request:
-    branches:
-       - main
 
 jobs:
   unit-tests:
@@ -28,7 +23,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("",false);
+            test_struct = runUnitTests("save",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             addpath("${{ github.workspace }}/k-Wave");
             cd("${{ github.workspace }}/k-Wave/testing/unit");
-            test_struct = runUnitTests("",false);
+            test_struct = runUnitTests("kWaveDiffusion_compare_3D_heterog",false);
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
             save('test_struct.mat', 'test_struct');
           startup-options: -nojvm -logfile output.log
 
-      - name: Show test results & create artifact
+      - name: Show test results 
         uses: matlab-actions/run-command@v2
         with:
           command: |
@@ -35,6 +35,15 @@ jobs:
             cd("${{ github.workspace }}/k-Wave/testing/unit");
             load('test_struct.mat', 'test_struct');
             runUnitTests_show_results(test_struct);
+          startup-options: -nojvm 
+
+      - name: Create artifact
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            addpath("${{ github.workspace }}/k-Wave");
+            cd("${{ github.workspace }}/k-Wave/testing/unit");
+            load('test_struct.mat', 'test_struct');
             runUnitTests_artifact(test_struct);
           startup-options: -nojvm 
 

--- a/k-Wave/testing/unit/runUnitTests_artifact.m
+++ b/k-Wave/testing/unit/runUnitTests_artifact.m
@@ -14,6 +14,3 @@ else
     fclose(fid);
 end
 
-disp(' ');
-disp('UNIT TEST RESULTS SAVED TO test_results.json');
-disp(' ');

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -49,6 +49,7 @@ if ~isempty(failed_idx)
         fn = fn(1:end - 2);
         disp(['❌  ' fn 'failed']);
     end
+    disp('  ');
 end
 
 % display individual test results
@@ -81,10 +82,8 @@ disp('You can also download a JSON summary from the "Upload Artifact" section in
 disp('  ');
 % Fail if any tests failed (for CI integration)
 if num_failed > 0
-    disp('Some of the tests have failed.');
-    disp('For details see the above.');
     disp('  ');
-    disp('Exiting so that CI detects failed tests.');
+    disp('Exiting so that CI detects test failure.');
     exit(1);
 end
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -78,8 +78,12 @@ disp('NOTE:');
 disp('Test output details are in the "Run unit tests" section of the workflow.');
 disp('You can also download a JSON summary from the "Upload Artifact" section in your CI logs or dashboard.');
 
+disp('  ');
 % Fail if any tests failed (for CI integration)
 if num_failed > 0
+    disp('Some of the tests have failed.');
+    disp('For details see the above.');
     disp('  ');
-    error('Some unit tests failed. See above for details.');
+    exit(0);
+end
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -84,6 +84,6 @@ if num_failed > 0
     disp('Some of the tests have failed.');
     disp('For details see the above.');
     disp('  ');
-    exit(0);
+    exit(1);
 end
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -79,5 +79,5 @@ disp('You can also download a JSON summary from the "Upload Artifact" section in
 
 % Fail if any tests failed (for CI integration)
 if num_failed > 0
-    exit(1);
+    error('Some unit tests failed. See above for details.');
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -71,6 +71,7 @@ for i = 1:length(results)
     end
     
 end
+disp('  ');
 
 % display test summary
 disp('NOTE:');
@@ -79,5 +80,6 @@ disp('You can also download a JSON summary from the "Upload Artifact" section in
 
 % Fail if any tests failed (for CI integration)
 if num_failed > 0
+    disp('  ');
     error('Some unit tests failed. See above for details.');
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -84,6 +84,7 @@ if num_failed > 0
     disp('Some of the tests have failed.');
     disp('For details see the above.');
     disp('  ');
+    disp('Exiting so that CI detects failed tests.');
     exit(1);
 end
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -2,11 +2,8 @@ function runUnitTests_show_results(test_struct)
 %RUNUNITTESTS_SHOW_RESULTS Display MATLAB unit test results in a formatted summary.
 %
 % DESCRIPTION:
-%     runUnitTests_show_results displays the results from the provided test_struct
-%     in a formatted summary, including test details, individual test outcomes,
-%     and a summary of passed and failed tests.
+%     runUnitTests_show_results displays the results from the provided test_struct.
 %
-
 % =========================================================================
 % DISPLAY SUMMARY
 % =========================================================================
@@ -35,6 +32,25 @@ disp(['TESTED K-WAVE VERSION:    ' info.kwave_version]);
 disp(['TESTS COMPLETED IN:       ' info.completion_time]);
 disp('  ');
 
+% display test summary
+disp('  ');
+num_passed = sum([results.pass]);
+num_failed = numel(results) - num_passed;
+disp(['✅ Number of tests passed: ' num2str(num_passed)]);
+disp(['❌ Number of tests failed: ' num2str(num_failed)]);
+disp('  ');
+
+% Show failed tests using test_struct
+failed_idx = find(~[results.pass]);
+if ~isempty(failed_idx)
+    disp('FAILED TESTS:');
+    for i = failed_idx
+        fn = results(i).test;
+        fn = fn(1:end - 2);
+        disp(['❌  ' fn 'failed']);
+    end
+end
+
 % display individual test results
 disp('UNIT TEST RESULTS:');
 
@@ -57,21 +73,6 @@ for i = 1:length(results)
 end
 
 % display test summary
-disp('  ');
-disp('UNIT TEST SUMMARY:');
-num_passed = sum([results.pass]);
-num_failed = numel(results) - num_passed;
-disp(['✅ Number of tests passed: ' num2str(num_passed)]);
-disp(['❌ Number of tests failed: ' num2str(num_failed)]);
-disp('  ');
-
-% Show failed tests using test_struct
-failed_idx = find(~[results.pass]);
-if ~isempty(failed_idx)
-    disp('❌ FAILED TESTS:');
-    for i = failed_idx
-        fn = results(i).test;
-        fn = fn(1:end - 2);
-        disp(fn);
-    end
-end
+disp('NOTE:');
+disp('Test output details are in the "Run unit tests" section of the workflow.');
+disp('You can also download a JSON summary from the "Upload Artifact" section in your CI logs or dashboard.');

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -49,9 +49,9 @@ for i = 1:length(results)
     
     % append the test result
     if results(i).pass
-        disp(['  ' fn 'passed']);
+        disp(['✅  ' fn 'passed']);
     else
-        disp(['  ' fn 'failed']);
+        disp(['❌  ' fn 'failed']);
     end
     
 end
@@ -73,9 +73,5 @@ if ~isempty(failed_idx)
         fn = results(i).test;
         fn = fn(1:end - 2);
         disp(fn);
-        if ~isempty(results(i).test_info)
-            fprintf('%s\n', results(i).test_info);
-            disp('  ');
-        end
     end
 end

--- a/k-Wave/testing/unit/runUnitTests_show_results.m
+++ b/k-Wave/testing/unit/runUnitTests_show_results.m
@@ -76,3 +76,8 @@ end
 disp('NOTE:');
 disp('Test output details are in the "Run unit tests" section of the workflow.');
 disp('You can also download a JSON summary from the "Upload Artifact" section in your CI logs or dashboard.');
+
+% Fail if any tests failed (for CI integration)
+if num_failed > 0
+    exit(1);
+end


### PR DESCRIPTION
**What does this PR do?**
`runUnitTests_show_results`: 
- improved order in which the test results are shown (number of passed / failed tests and list of failed tests are shown at the top)
- colour coding for clarity (✅ / ❌)
- adds a note at the end of the test results report on how to find more test details (e.g. by downloading the artifact)
- non zero exit code if at the end of the report so that CI fails if there are failed tests (this will also draw immediate attention to the section in the CI report that shows the test results)

`unit_tests.yml`:
- seperates _create artifact_ and _test results_  workflow steps for increased clarity in the report
- reordering and renaming of some of the workflow steps for clarity

See the new CI output [here](https://github.com/stellaprins/k-wave/actions/runs/16615937384) (once it has finished running).

**Linked issues**
#9 


