### PR TITLE
#26 Updated kwavehelpstyle.css to improve help formatting

### DIFF
--- a/k-Wave/helpfiles/kwavehelpstyle.css
+++ b/k-Wave/helpfiles/kwavehelpstyle.css
@@ -36,9 +36,8 @@ ol li ol li { list-style-type:lower-alpha; }
 ol li ul { padding-top:7px; }
 ol li ul li { list-style:square; }
 
-.content { font-size:1.2em; line-height:140%; padding: 20px; }
+.content { line-height:140%; padding: 20px; }
 
-pre, code { font-size:12px; }
 tt { font-size: 1.2em; }
 pre { margin:0px 0px 20px; }
 pre.codeinput { padding:10px; border:1px solid #d3d3d3; background:#f7f7f7; }


### PR DESCRIPTION
Changed two lines in the css file in the help folder so that the help files show with sensible font sizes.